### PR TITLE
Fix Crystal skull chest logic in Heaven's Labyrinth

### DIFF
--- a/LM2Randomiser/LM2Randomiser/Data/rules.json
+++ b/LM2Randomiser/LM2Randomiser/Data/rules.json
@@ -682,7 +682,7 @@
     "areaName":"Heavens Labyrinth",
     "locations": [
       "Map Chest HL: True",
-      "Crystal Skull Chest HL: True",
+      "Crystal Skull Chest HL: Has(Grapple Claw) and Has(Feather)",
       "Megarock Shop 1: Has(Grapple Claw) and Has(Feather)",
       "Megarock Shop 2: Has(Grapple Claw) and Has(Feather)",
       "Megarock Shop 3: Has(Grapple Claw) and Has(Feather)"


### PR DESCRIPTION
To get the block moving, you need to go by the shop in the screen below, so adding same requirements.