### PR TITLE
Ancient Chaos Transition Logic

### DIFF
--- a/LaMulana2Randomizer/Data/World.json
+++ b/LaMulana2Randomizer/Data/World.json
@@ -3051,7 +3051,7 @@
       {
         "ConnectionType": "Internal",
         "ConnectingAreaID": "ACBlood",
-        "Logic": "Has(Bomb)"
+        "Logic": "CanUse(Bomb)"
       }
     ]
   },

--- a/LaMulana2Randomizer/Data/World.json
+++ b/LaMulana2Randomizer/Data/World.json
@@ -2952,7 +2952,7 @@
         "ID": "f12GateP0",
         "ConnectionType": "Gate",
         "ConnectingAreaID": "TSBottom",
-        "Logic": "False or Setting(Random Gates)"
+        "Logic": "True"
       }
     ]
   },
@@ -3051,7 +3051,7 @@
       {
         "ConnectionType": "Internal",
         "ConnectingAreaID": "ACBlood",
-        "Logic": "Has(Winner) and Has(Bomb)"
+        "Logic": "Has(Bomb)"
       }
     ]
   },


### PR DESCRIPTION
Currently, the ancient chaos logic wrongly assumes that you can not do things that you can in fact do.

Firstly, the bombable tube at the top of Ancient Chaos, can in fact be bombed without any endgame flags, or any flag for that matter! It has been tested in a fresh AC start seed that has done literally nothing, and you can in fact just go and bomb the tunnel immediately.
Climbing up without feather is a bit of a pain, but that is already in logic with Nothing, for AC Main->AC Tablet, so I see no need in adding requirements to climbing up the Wind Mural room, as that is out of the scope of this PR.


Secondly, the gate from AC to Taka, can in fact just be gone through, despite looking closed. 
Well, I think it can, anyways. I've done it in a rando seed without gate rando, and I do not think that rando would change this behavior? So this is *probably* vanilla behavior and its fine to have. Maybe do a double check that it works like this though. Just to be sure. But seeing how in intended gameplay you would have no way of accessing this gate from the wrong side, I think it is reasonable to assume that nigoro just never made the gate not work while closed.

Maybe add these to the obscure interactions wiki page, as well though. Since they are somewhat obscure, seeing how it has taken this long for a PR to be made :P